### PR TITLE
Document MC-prod release MC-prod-2026-v11

### DIFF
--- a/docs/mc-software-releases/README.md
+++ b/docs/mc-software-releases/README.md
@@ -8,10 +8,11 @@ title: MC Software Releases
 This page lists the current release for the MC software stack to be used in
 GRID productions.
 
-The current production release for MC is `O2PDPSuite::MC-prod-2026-v10-1`. ([Release notes](https://github.com/sawenzel/MCReleasePrototype/blob/main/releases/release-notes/release-notes-O2PDPSuite%3A%3AMC-prod-2026-v10.md))
+The current production release for MC is `O2PDPSuite::MC-prod-2026-v11-1`. ([Release notes](https://github.com/sawenzel/MCReleasePrototype/blob/main/releases/release-notes/release-notes-O2PDPSuite-MC-prod-2026-v11.md))
 
 ## Stable MC Software Releases
 
+<!-- release-table:start -->
 | Version                         | Status  | Date       | Comments                                                                                       |
 |---------------------------------|---------|------------|------------------------------------------------------------------------------------------------|
 | `O2PDPSuite::MC-prod-2025-v1-2` | Stable  | —          | Produced from master/dev                                                                       |
@@ -34,5 +35,6 @@ The current production release for MC is `O2PDPSuite::MC-prod-2026-v10-1`. ([Rel
 | `O2DPGSuite::MC-prod-2026-v7-1` | More AOD MC corruptions | 06/05/2026 | Produced from daily tag `O2DPGSuite::daily-20260506-0000-1`. Fix of problem in AODBcRewriter (corrupted MC particle data). [Release notes](https://github.com/sawenzel/MCReleasePrototype/blob/main/releases/release-notes/release-notes-O2PDPSuite%3A%3AMC-prod-2026-v7.md) |
 | `O2DPGSuite::MC-prod-2026-v8-1` | More AOD MC corruptions | 06/05/2026 | Produced from daily tag `O2DPGSuite::daily-20260522-0000-1`. Fix more problems in AODBcRewriter (non-joinable MC tables). [Release notes](https://github.com/sawenzel/MCReleasePrototype/blob/main/releases/release-notes/release-notes-O2PDPSuite%3A%3AMC-prod-2026-v8.md) |
 | `O2DPGSuite::MC-prod-2026-v9-1` | stable | 12/06/2026 | Produced from daily tag `O2DPGSuite::daily-20260612-0000-1`. Fix more problems in AODBcRewriter (non-joinable MC tables). [Release notes](https://github.com/sawenzel/MCReleasePrototype/blob/main/releases/release-notes/release-notes-O2PDPSuite%3A%3AMC-prod-2026-v9.md) |
-| `O2DPGSuite::MC-prod-2026-v10-1` | current | 29/06/2026 | Produced from daily tag `O2DPGSuite::daily-20260629-0000-1`. FIT crosstalk effect in digitization. [Release notes](https://github.com/sawenzel/MCReleasePrototype/blob/main/releases/release-notes/release-notes-O2PDPSuite%3A%3AMC-prod-2026-v10.md) |
-
+| `O2DPGSuite::MC-prod-2026-v10-1` | Stable | 29/06/2026 | Produced from daily tag `O2DPGSuite::daily-20260629-0000-1`. FIT crosstalk effect in digitization. [Release notes](https://github.com/sawenzel/MCReleasePrototype/blob/main/releases/release-notes/release-notes-O2PDPSuite%3A%3AMC-prod-2026-v10.md) |
+| `O2PDPSuite::MC-prod-2026-v11-1` | current | 29/07/2026 | Produced from daily tag `O2PDPSuite::daily-20260729-0000-1`. First release cut and documented by the new agentic mc-release pipeline. [Release notes](https://github.com/sawenzel/MCReleasePrototype/blob/main/releases/release-notes/release-notes-O2PDPSuite-MC-prod-2026-v11.md) |
+<!-- release-table:end -->


### PR DESCRIPTION
Adds `MC-prod-2026-v11` (based on `daily-20260729-0000-1`) to the release table.

First release documented by the new agentic mc-release pipeline (O2DPGAgentic). Fixes a broken page (front matter only, no release content, plus a corrupted trailing artifact).